### PR TITLE
Cah/fugacity

### DIFF
--- a/include/CoolPropLib.h
+++ b/include/CoolPropLib.h
@@ -369,6 +369,38 @@ EXPORT_CODE void CONVENTION AbstractState_get_mole_fractions_satState(const long
                                                                       const long maxN, long* N, long* errcode, char* message_buffer,
                                                                       const long buffer_length);
 /**
+     * @brief Return the fugacity of the i-th component of the mixture.
+     * @param handle The integer handle for the state class stored in memory
+     * @param i i-th component of the mixture
+     * @param errcode The errorcode that is returned (0 = no error, !0 = error)
+     * @param message_buffer A buffer for the error code
+     * @param buffer_length The length of the buffer for the error code
+     * @return 
+     */
+EXPORT_CODE double CONVENTION AbstractState_get_fugacity(const long handle, const std::size_t i, long* errcode, char* message_buffer,
+                                                         const long buffer_length);
+/**
+     * @brief Return the fugacity coefficient of the i-th component of the mixture.
+     * @param handle The integer handle for the state class stored in memory
+     * @param i i-th component of the mixture
+     * @param errcode The errorcode that is returned (0 = no error, !0 = error)
+     * @param message_buffer A buffer for the error code
+     * @param buffer_length The length of the buffer for the error code
+     * @return 
+     */
+EXPORT_CODE double CONVENTION AbstractState_get_fugacity_coefficient(const long handle, const std::size_t i, long* errcode, char* message_buffer,
+                                                                      const long buffer_length);
+// TODO: update once the AbstractState_get_fugacity_coefficients function is verified to be correct
+// /**
+//      * @brief Return a vector of the fugacity coefficients for all components in the mixture.
+//      * @param handle The integer handle for the state class stored in memory
+//      * @param errcode The errorcode that is returned (0 = no error, !0 = error)
+//      * @param message_buffer A buffer for the error code
+//      * @param buffer_length The length of the buffer for the error code
+//      * @return 
+//      */
+// EXPORT_CODE double CONVENTION AbstractState_get_fugacity_coefficients(const long handle, long* errcode, char* message_buffer, const long buffer_length);
+/**
      * @brief Update the state of the AbstractState
      * @param handle The integer handle for the state class stored in memory
      * @param input_pair The integer value for the input pair obtained from XXXXXXXXXXXXXXXX

--- a/include/CoolPropLib.h
+++ b/include/CoolPropLib.h
@@ -377,7 +377,7 @@ EXPORT_CODE void CONVENTION AbstractState_get_mole_fractions_satState(const long
      * @param buffer_length The length of the buffer for the error code
      * @return 
      */
-EXPORT_CODE double CONVENTION AbstractState_get_fugacity(const long handle, const std::size_t i, long* errcode, char* message_buffer,
+EXPORT_CODE double CONVENTION AbstractState_get_fugacity(const long handle, const long i, long* errcode, char* message_buffer,
                                                          const long buffer_length);
 /**
      * @brief Return the fugacity coefficient of the i-th component of the mixture.
@@ -388,18 +388,8 @@ EXPORT_CODE double CONVENTION AbstractState_get_fugacity(const long handle, cons
      * @param buffer_length The length of the buffer for the error code
      * @return 
      */
-EXPORT_CODE double CONVENTION AbstractState_get_fugacity_coefficient(const long handle, const std::size_t i, long* errcode, char* message_buffer,
+EXPORT_CODE double CONVENTION AbstractState_get_fugacity_coefficient(const long handle, const long i, long* errcode, char* message_buffer,
                                                                       const long buffer_length);
-// TODO: update once the AbstractState_get_fugacity_coefficients function is verified to be correct
-// /**
-//      * @brief Return a vector of the fugacity coefficients for all components in the mixture.
-//      * @param handle The integer handle for the state class stored in memory
-//      * @param errcode The errorcode that is returned (0 = no error, !0 = error)
-//      * @param message_buffer A buffer for the error code
-//      * @param buffer_length The length of the buffer for the error code
-//      * @return 
-//      */
-// EXPORT_CODE double CONVENTION AbstractState_get_fugacity_coefficients(const long handle, long* errcode, char* message_buffer, const long buffer_length);
 /**
      * @brief Update the state of the AbstractState
      * @param handle The integer handle for the state class stored in memory

--- a/src/CoolPropLib.cpp
+++ b/src/CoolPropLib.cpp
@@ -604,8 +604,7 @@ EXPORT_CODE void CONVENTION AbstractState_get_mole_fractions_satState(const long
         HandleException(errcode, message_buffer, buffer_length);
     }
 }
-// TODO: verify this is correct
-EXPORT_CODE double CONVENTION AbstractState_get_fugacity(const long handle, const std::size_t i, long* errcode, char* message_buffer,
+EXPORT_CODE double CONVENTION AbstractState_get_fugacity(const long handle, const long i, long* errcode, char* message_buffer,
                                                          const long buffer_length) {
     *errcode = 0;
     try {
@@ -616,8 +615,7 @@ EXPORT_CODE double CONVENTION AbstractState_get_fugacity(const long handle, cons
     }
     return _HUGE;
 }
-// TODO: verify this is correct
-EXPORT_CODE double CONVENTION AbstractState_get_fugacity_coefficient(const long handle, const std::size_t i, long* errcode, char* message_buffer,
+EXPORT_CODE double CONVENTION AbstractState_get_fugacity_coefficient(const long handle, const long i, long* errcode, char* message_buffer,
                                                                     const long buffer_length) {
     *errcode = 0;
     try {
@@ -628,19 +626,6 @@ EXPORT_CODE double CONVENTION AbstractState_get_fugacity_coefficient(const long 
     }
     return _HUGE;
 }
-// TODO: verify this is correct
-// Am I returning vectors correctly??
-// EXPORT_CODE vector<std::double> CONVENTION AbstractState_get_fugacity_coefficients(const long handle, const std::size_t i, long* errcode, char* message_buffer,
-//                                                                     const long buffer_length) {
-//     *errcode = 0;
-//     try {
-//         shared_ptr<CoolProp::AbstractState>& AS = handle_manager.get(handle);
-//         return AS->fugacity_coefficients(i);
-//     } catch (...) {
-//         HandleException(errcode, message_buffer, buffer_length);
-//     }
-//     return _HUGE;
-// }
 EXPORT_CODE void CONVENTION AbstractState_update(const long handle, const long input_pair, const double value1, const double value2, long* errcode,
                                                  char* message_buffer, const long buffer_length) {
     *errcode = 0;

--- a/src/CoolPropLib.cpp
+++ b/src/CoolPropLib.cpp
@@ -604,6 +604,43 @@ EXPORT_CODE void CONVENTION AbstractState_get_mole_fractions_satState(const long
         HandleException(errcode, message_buffer, buffer_length);
     }
 }
+// TODO: verify this is correct
+EXPORT_CODE double CONVENTION AbstractState_get_fugacity(const long handle, const std::size_t i, long* errcode, char* message_buffer,
+                                                         const long buffer_length) {
+    *errcode = 0;
+    try {
+        shared_ptr<CoolProp::AbstractState>& AS = handle_manager.get(handle);
+        return AS->fugacity(i);
+    } catch (...) {
+        HandleException(errcode, message_buffer, buffer_length);
+    }
+    return _HUGE;
+}
+// TODO: verify this is correct
+EXPORT_CODE double CONVENTION AbstractState_get_fugacity_coefficient(const long handle, const std::size_t i, long* errcode, char* message_buffer,
+                                                                    const long buffer_length) {
+    *errcode = 0;
+    try {
+        shared_ptr<CoolProp::AbstractState>& AS = handle_manager.get(handle);
+        return AS->fugacity_coefficient(i);
+    } catch (...) {
+        HandleException(errcode, message_buffer, buffer_length);
+    }
+    return _HUGE;
+}
+// TODO: verify this is correct
+// Am I returning vectors correctly??
+// EXPORT_CODE vector<std::double> CONVENTION AbstractState_get_fugacity_coefficients(const long handle, const std::size_t i, long* errcode, char* message_buffer,
+//                                                                     const long buffer_length) {
+//     *errcode = 0;
+//     try {
+//         shared_ptr<CoolProp::AbstractState>& AS = handle_manager.get(handle);
+//         return AS->fugacity_coefficients(i);
+//     } catch (...) {
+//         HandleException(errcode, message_buffer, buffer_length);
+//     }
+//     return _HUGE;
+// }
 EXPORT_CODE void CONVENTION AbstractState_update(const long handle, const long input_pair, const double value1, const double value2, long* errcode,
                                                  char* message_buffer, const long buffer_length) {
     *errcode = 0;

--- a/src/CoolPropLib.def
+++ b/src/CoolPropLib.def
@@ -15,6 +15,8 @@ EXPORTS
   AbstractState_update_and_1_out = _AbstractState_update_and_1_out@40
   AbstractState_update_and_5_out = _AbstractState_update_and_5_out@56
   AbstractState_update_and_common_out = _AbstractState_update_and_common_out@52
+  AbstractState_get_fugacity = _AbstractState_get_fugacity@20
+  AbstractState_get_fugacity_coefficient = _AbstractState_get_fugacity_coefficient@20
   F2K = _F2K@8
   HAProps = _HAProps@40
   HAPropsSI = _HAPropsSI@40

--- a/src/CoolPropLib.def
+++ b/src/CoolPropLib.def
@@ -15,8 +15,6 @@ EXPORTS
   AbstractState_update_and_1_out = _AbstractState_update_and_1_out@40
   AbstractState_update_and_5_out = _AbstractState_update_and_5_out@56
   AbstractState_update_and_common_out = _AbstractState_update_and_common_out@52
-  AbstractState_get_fugacity = _AbstractState_get_fugacity@20
-  AbstractState_get_fugacity_coefficient = _AbstractState_get_fugacity_coefficient@20
   F2K = _F2K@8
   HAProps = _HAProps@40
   HAPropsSI = _HAPropsSI@40


### PR DESCRIPTION
Add C++ fugacity calls which enable them to be wrapped in CoolProp.jl. 

This was already successfully merged with CoolProp.  https://github.com/CoolProp/CoolProp/pull/2286 

Merging it locally now. 
